### PR TITLE
Improve Resource.$loadPaths error messages

### DIFF
--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -686,22 +686,28 @@ angular.module('hypermedia')
        * @return {Promise} a promise that resolves to the resource once all
        *                   paths have been loaded
        */
-      $loadPaths: {value: function (paths) {
+      $loadPaths: {value: function (paths, path_prefix, root_uri) {
         var self = this;
+        if (!path_prefix) {
+          path_prefix = [];
+          root_uri = self.$uri;
+        }
         return self.$load().then(function () {
           var promises = [];
           Object.keys(paths).forEach(function (key) {
+            var full_path = path_prefix.concat(key);
             var uris = self.$propHref(key);
             if (!uris) uris = self.$linkHref(key);
             if (!uris) {
-              $log.warn('path "' + key + '" not found for resource: ' + self.$uri);
+              $log.warn('Warning while loading path "' + full_path.join('.') + '" from resource "' + root_uri + '": ' +
+                  'property or link "' + key + '" not found on resource "' + self.$uri + '"');
               return;
             }
 
             uris = angular.isArray(uris) ? uris : [uris];
             uris.forEach(function (uri) {
               var related = (typeof uri === 'string') ? self.$context.get(uri) : uri;
-              promises.push(related.$loadPaths(paths[key]));
+              promises.push(related.$loadPaths(paths[key], full_path, root_uri));
             });
           });
           return $q.all(promises);

--- a/src/resource.js
+++ b/src/resource.js
@@ -242,22 +242,28 @@ angular.module('hypermedia')
        * @return {Promise} a promise that resolves to the resource once all
        *                   paths have been loaded
        */
-      $loadPaths: {value: function (paths) {
+      $loadPaths: {value: function (paths, path_prefix, root_uri) {
         var self = this;
+        if (!path_prefix) {
+          path_prefix = [];
+          root_uri = self.$uri;
+        }
         return self.$load().then(function () {
           var promises = [];
           Object.keys(paths).forEach(function (key) {
+            var full_path = path_prefix.concat(key);
             var uris = self.$propHref(key);
             if (!uris) uris = self.$linkHref(key);
             if (!uris) {
-              $log.warn('path "' + key + '" not found for resource: ' + self.$uri);
+              $log.warn('Warning while loading path "' + full_path.join('.') + '" from resource "' + root_uri + '": ' +
+                  'property or link "' + key + '" not found on resource "' + self.$uri + '"');
               return;
             }
 
             uris = angular.isArray(uris) ? uris : [uris];
             uris.forEach(function (uri) {
               var related = (typeof uri === 'string') ? self.$context.get(uri) : uri;
-              promises.push(related.$loadPaths(paths[key]));
+              promises.push(related.$loadPaths(paths[key], full_path, root_uri));
             });
           });
           return $q.all(promises);

--- a/src/resource.spec.js
+++ b/src/resource.spec.js
@@ -266,7 +266,7 @@ describe('Resource', function () {
     });
 
     resource.$loadPaths({nonexistent: {}}).then(function () {
-      expect($log.warn).toHaveBeenCalledWith('path "nonexistent" not found for resource: http://example.com');
+      expect($log.warn).toHaveBeenCalledWith('Warning while loading path "nonexistent" from resource "http://example.com": property or link "nonexistent" not found on resource "http://example.com"');
       done();
     });
     $rootScope.$digest();


### PR DESCRIPTION
Old error:

```
path "nonexistent" not found for resource: http://example.com/resource2
```

New error:

```
Warning while loading path "relation1.relation2" from resource "http://example.com/resource1": property or link "nonexistent" not found on resource "http://example.com/resource2"
```
