### PR TITLE
Remove resource from context in httpDelete

### DIFF
--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -239,6 +239,7 @@ angular.module('hypermedia')
         busyRequests += 1;
         var request = updateHttp(resource.$deleteRequest());
         return $http(request).then(function () {
+          delete self.resources[resource.$uri];
           return self.markSynced(resource, null);
         }).then(function () {
           return resource;

--- a/src/context.js
+++ b/src/context.js
@@ -145,6 +145,7 @@ angular.module('hypermedia')
         busyRequests += 1;
         var request = updateHttp(resource.$deleteRequest());
         return $http(request).then(function () {
+          delete self.resources[resource.$uri];
           return self.markSynced(resource, null);
         }).then(function () {
           return resource;

--- a/src/context.spec.js
+++ b/src/context.spec.js
@@ -105,6 +105,7 @@ describe('ResourceContext', function () {
     $httpBackend.flush();
     expect(promiseResult).toBe(resource);
     expect(resource.$syncTime).toBeNull();
+    expect(context.get(resource.$uri)).not.toBe(resource);
   });
 
   it('performs HTTP POST requests', function () {


### PR DESCRIPTION
This change makes `ResourceContext.httpDelete` remove the resource from the context.

@mvcatsifma Is this a good idea, or should we have a separate `ResourceContext.remove` method?
