### PR TITLE
Fix content type for errors

### DIFF
--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -1015,7 +1015,7 @@ angular.module('hypermedia')
       return new VndError(response.data);
     };
 
-    ResourceContext.registerErrorHandler('application/vnd+error', vndErrorHandler);
+    ResourceContext.registerErrorHandler('application/vnd.error+json', vndErrorHandler);
   })
 
   /**

--- a/src/context.spec.js
+++ b/src/context.spec.js
@@ -57,14 +57,14 @@ describe('ResourceContext', function () {
     expect(promiseResult.status).toBe(500);
   });
 
-  it('invokes default error handler for content type "application/vnd+error"', function () {
+  it('invokes default error handler for content type "application/vnd.error+json"', function () {
     var promiseResult;
     var msg = 'Validatie fout';
     context.httpGet(resource).catch(function (result) {
       promiseResult = result;
     });
     $httpBackend.expectGET(resource.$uri, {'Accept': 'application/json'})
-      .respond(500, {message: msg}, {'Content-Type': 'application/vnd+error'});
+      .respond(500, {message: msg}, {'Content-Type': 'application/vnd.error+json'});
     $httpBackend.flush();
 
     expect(promiseResult.error).toBeDefined();

--- a/src/vnderror.js
+++ b/src/vnderror.js
@@ -7,7 +7,7 @@ angular.module('hypermedia')
       return new VndError(response.data);
     };
 
-    ResourceContext.registerErrorHandler('application/vnd+error', vndErrorHandler);
+    ResourceContext.registerErrorHandler('application/vnd.error+json', vndErrorHandler);
   })
 
   /**


### PR DESCRIPTION
It was defined as application/vnd+error but should be
application/vnd.error+json according to the spec.
