### PR TITLE
Add optional parameters to $get

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ completes successfully.
       console.log('success!');
     });
 
+The `$get` method can also be called with optional parameters.
+
+**Example**
+
+    // requests 'http://example.com/composer/john?food=pineapple'
+    context.get('http://example.com/composer/john').$get({food: 'pineapple'});
 
 ## PATCH requests: synchronization using JSON Merge Patch
 

--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -51,10 +51,11 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': '*/*'},
@@ -63,6 +64,8 @@ angular.module('hypermedia')
             return {data: data};
           }
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**
@@ -179,13 +182,14 @@ angular.module('hypermedia')
        *
        * @function
        * @param {Resource} resource
+       * @param {object} [params] additional GET parameters
        * @returns a promise that is resolved to the resource
        * @see Resource#$getRequest
        */
-      httpGet: {value: function (resource) {
+      httpGet: {value: function (resource, params) {
         var self = this;
         busyRequests += 1;
-        var request = updateHttp(resource.$getRequest());
+        var request = updateHttp(resource.$getRequest(params));
         return $http(request).then(function (response) {
           var links = parseLinkHeader(response.headers('Link'));
 
@@ -400,14 +404,17 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': 'application/hal+json'}
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**
@@ -753,24 +760,30 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': 'application/json'}
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**
        * Perform an HTTP GET request.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns a promise that is resolved to the resource
        */
-      $get: {value: function () {
-        return this.$context.httpGet(this);
+      $get: {value: function (params) {
+        var args = [this];
+        if (params) args.push(params);
+        return this.$context.httpGet.apply(this.$context, args);
       }},
 
       /**

--- a/src/blobresource.js
+++ b/src/blobresource.js
@@ -39,10 +39,11 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': '*/*'},
@@ -51,6 +52,8 @@ angular.module('hypermedia')
             return {data: data};
           }
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**

--- a/src/blobresource.spec.js
+++ b/src/blobresource.spec.js
@@ -39,6 +39,18 @@ describe('BlobResource', function () {
     });
   });
 
+  it('creates HTTP GET request with additional GET parameters', function () {
+    var params = {name: 'John'};
+    expect(resource.$getRequest(params)).toEqual({
+      method: 'get',
+      url: 'http://example.com',
+      headers: {Accept: '*/*'},
+      responseType: 'blob',
+      params: params,
+      addTransformResponse: jasmine.any(Function)
+    });
+  });
+
   it('creates HTTP PUT request using the data media type', function () {
     resource.data = new Blob(['test'], {type: 'text/plain'});
     expect(resource.$putRequest()).toEqual({

--- a/src/context.js
+++ b/src/context.js
@@ -84,13 +84,14 @@ angular.module('hypermedia')
        *
        * @function
        * @param {Resource} resource
+       * @param {object} [params] additional GET parameters
        * @returns a promise that is resolved to the resource
        * @see Resource#$getRequest
        */
-      httpGet: {value: function (resource) {
+      httpGet: {value: function (resource, params) {
         var self = this;
         busyRequests += 1;
-        var request = updateHttp(resource.$getRequest());
+        var request = updateHttp(resource.$getRequest(params));
         return $http(request).then(function (response) {
           var links = parseLinkHeader(response.headers('Link'));
 

--- a/src/context.spec.js
+++ b/src/context.spec.js
@@ -102,6 +102,13 @@ describe('ResourceContext', function () {
     expect(resource.$syncTime / 100).toBeCloseTo(Date.now() / 100, 0);
   });
 
+  it('performs HTTP GET request with additional GET parameters', function () {
+    context.httpGet(resource, {name: 'John'});
+    $httpBackend.expectGET(resource.$uri + '?name=John')
+        .respond('{}', {'Content-Type': 'application/json'});
+    $httpBackend.flush();
+  });
+
   it('converts content type profile parameter to link', function () {
     var promiseResult = null;
     context.httpGet(resource).then(function (result) {

--- a/src/halresource.js
+++ b/src/halresource.js
@@ -31,14 +31,17 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': 'application/hal+json'}
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**

--- a/src/halresource.spec.js
+++ b/src/halresource.spec.js
@@ -37,6 +37,16 @@ describe('HalResource', function () {
     });
   });
 
+  it('creates HTTP GET request for HAL data with additional GET parameters', function () {
+    var params = {name: 'John'};
+    expect(resource.$getRequest(params)).toEqual({
+      method: 'get',
+      url: 'http://example.com',
+      params: params,
+      headers: {Accept: 'application/hal+json'}
+    });
+  });
+
   it('creates HTTP PUT request with JSON data', function () {
     expect(resource.$putRequest()).toEqual({
       method: 'put',

--- a/src/resource.js
+++ b/src/resource.js
@@ -276,24 +276,30 @@ angular.module('hypermedia')
        * Create a $http GET request configuration object.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns {object}
        */
-      $getRequest: {value: function () {
-        return {
+      $getRequest: {value: function (params) {
+        var config = {
           method: 'get',
           url: this.$uri,
           headers: {'Accept': 'application/json'}
         };
+        if (params) config.params = params;
+        return config;
       }},
 
       /**
        * Perform an HTTP GET request.
        *
        * @function
+       * @param {object} [params] additional GET parameters
        * @returns a promise that is resolved to the resource
        */
-      $get: {value: function () {
-        return this.$context.httpGet(this);
+      $get: {value: function (params) {
+        var args = [this];
+        if (params) args.push(params);
+        return this.$context.httpGet.apply(this.$context, args);
       }},
 
       /**

--- a/src/resource.spec.js
+++ b/src/resource.spec.js
@@ -288,6 +288,16 @@ describe('Resource', function () {
     });
   });
 
+  it('creates HTTP GET request with additional GET parameters', function () {
+    var params = {name: 'John'};
+    expect(resource.$getRequest(params)).toEqual({
+      method: 'get',
+      url: 'http://example.com',
+      params: params,
+      headers: {Accept: 'application/json'}
+    });
+  });
+
   it('delegates HTTP GET request to the context', function () {
     resource.$get();
     expect(mockContext.httpGet).toHaveBeenCalledWith(resource);


### PR DESCRIPTION
First of all, thank you very much for your hugely useful module.

Here I have added optional parameters to `$get`.
So one could use `resource.$get({ param1: 'foobar', param2: 42 }).then(...)` to add additional URL parameters.
