### PR TITLE
Allows overriding $merge method in resource implementation class

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -143,7 +143,7 @@ angular.module('hypermedia')
         busyRequests += 1;
         var request = updateHttp(resource.$patchRequest(data));
         return $http(request).then(function () {
-          Resource.prototype.$merge.call(resource, request.data);
+          resource.$merge(request.data);
           return self.markSynced(resource, Date.now());
         }, handleErrorResponse).then(function () {
           return resource;


### PR DESCRIPTION
I'm not sure if that Resource.prototype.$merge call was on purpose (can you clarify it?), but with that I'm unable to override method $merge in descendant class and make it not merge some fields (which I need in my application)
