### PR TITLE
Make context refresh smarter

### DIFF
--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -164,11 +164,12 @@ angular.module('hypermedia')
        *          the response of that request.
        *
        */
-      refresh: {value: function () {
+      refresh: {value: function (ts) {
+        if (!ts) ts = Date.now();
         var promises = [];
         angular.forEach(this.resources, function (resource) {
           if (resource.$isSynced) {
-            promises.push(resource.$get());
+            promises.push(resource.$load(ts));
           }
         });
         return $q.all(promises);
@@ -684,11 +685,11 @@ angular.module('hypermedia')
        * @returns a promise that is resolved to the resource
        * @see Resource#$syncTime
        */
-      $load: {value: function () {
-        if (this.$syncTime) {
-          return $q.when(this);
-        } else {
+      $load: {value: function (ts) {
+        if (!this.$syncTime || (ts && this.$syncTime < ts)) {
           return this.$context.httpGet(this);
+        } else {
+          return $q.when(this);
         }
       }},
 

--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -162,7 +162,7 @@ angular.module('hypermedia')
        * or if none was passsed, against current time millis.
        *
        * @function
-       * @param ts the timestamp to check against
+       * @param {number} ts the timestamp to check against
        * @returns {Promise} a promise that will be resolved with an array of all resources that
        *          were refreshed. If any of the requests fails, the promise will be rejected with
        *          the response of that request.

--- a/dist/hypermedia.js
+++ b/dist/hypermedia.js
@@ -157,8 +157,12 @@ angular.module('hypermedia')
 
       /**
        * Refresh all synchronized resources in the context by issuing a HTTP GET request on them.
+       * GET requests are only issued for resources that are stale. Staleness is defined by
+       * checking the resource's syncTime against the timestamp that is passed as argument,
+       * or if none was passsed, against current time millis.
        *
        * @function
+       * @param ts the timestamp to check against
        * @returns {Promise} a promise that will be resolved with an array of all resources that
        *          were refreshed. If any of the requests fails, the promise will be rejected with
        *          the response of that request.
@@ -679,9 +683,11 @@ angular.module('hypermedia')
       }},
 
       /**
-       * Perform an HTTP GET request if the resource is not synchronized.
+       * Perform an HTTP GET request if the resource is not synchronized or if
+       * the resource was synced before timestamp passed as argument.
        *
        * @function
+       * @param {number} ts timestamp to check against
        * @returns a promise that is resolved to the resource
        * @see Resource#$syncTime
        */

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,11 +4,11 @@ module.exports = function (config) {
   config.set({
 
     files: [
-      'node_modules/angular/angular.js',
-      'node_modules/angular-mocks/angular-mocks.js',
-      'node_modules/linkheader-parser/dist/linkheader-parser-browser.js',
-      'node_modules/mediatype-parser/dist/mediatype-parser-browser.js',
-      'node_modules/uri-templates/uri-templates.js',
+      'bower_components/angular/angular.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/linkheader-parser/dist/linkheader-parser-browser.js',
+      'bower_components/mediatype-parser/dist/mediatype-parser-browser.js',
+      'bower_components/uri-templates/uri-templates.js',
       'src/*.js'
     ],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,11 +4,11 @@ module.exports = function (config) {
   config.set({
 
     files: [
-      'bower_components/angular/angular.js',
-      'bower_components/angular-mocks/angular-mocks.js',
-      'bower_components/linkheader-parser/dist/linkheader-parser-browser.js',
-      'bower_components/mediatype-parser/dist/mediatype-parser-browser.js',
-      'bower_components/uri-templates/uri-templates.js',
+      'node_modules/angular/angular.js',
+      'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/linkheader-parser/dist/linkheader-parser-browser.js',
+      'node_modules/mediatype-parser/dist/mediatype-parser-browser.js',
+      'node_modules/uri-templates/uri-templates.js',
       'src/*.js'
     ],
 

--- a/src/context.js
+++ b/src/context.js
@@ -67,7 +67,7 @@ angular.module('hypermedia')
        * or if none was passsed, against current time millis.
        *
        * @function
-       * @param ts the timestamp to check against
+       * @param {number} ts the timestamp to check against
        * @returns {Promise} a promise that will be resolved with an array of all resources that
        *          were refreshed. If any of the requests fails, the promise will be rejected with
        *          the response of that request.

--- a/src/context.js
+++ b/src/context.js
@@ -69,11 +69,12 @@ angular.module('hypermedia')
        *          the response of that request.
        *
        */
-      refresh: {value: function () {
+      refresh: {value: function (ts) {
+        if (!ts) ts = Date.now();
         var promises = [];
         angular.forEach(this.resources, function (resource) {
           if (resource.$isSynced) {
-            promises.push(resource.$get());
+            promises.push(resource.$load(ts));
           }
         });
         return $q.all(promises);

--- a/src/context.js
+++ b/src/context.js
@@ -62,8 +62,12 @@ angular.module('hypermedia')
 
       /**
        * Refresh all synchronized resources in the context by issuing a HTTP GET request on them.
+       * GET requests are only issued for resources that are stale. Staleness is defined by
+       * checking the resource's syncTime against the timestamp that is passed as argument,
+       * or if none was passsed, against current time millis.
        *
        * @function
+       * @param ts the timestamp to check against
        * @returns {Promise} a promise that will be resolved with an array of all resources that
        *          were refreshed. If any of the requests fails, the promise will be rejected with
        *          the response of that request.

--- a/src/context.spec.js
+++ b/src/context.spec.js
@@ -193,14 +193,22 @@ describe('ResourceContext', function () {
     expect(ResourceContext.busyRequests).toBe(0);
   });
 
-  it('gets synced resources on refresh', function () {
+  it('gets synced resources on refresh and stale', function () {
+    var ts = Date.now();
     resource.$syncTime = 1;
     var resource2 = context.get('http://example.com/other');
     $httpBackend.expectGET(resource.$uri, {'Accept': 'application/json'})
       .respond('{"name": "John"}', {'Content-Type': 'application/json'});
-    context.refresh();
+    context.refresh(ts);
     $httpBackend.flush();
     expect(resource.name).toBe('John');
     expect(resource2.$isSynced).toBe(false);
   });
+
+  it('does not get synced resources on refresh', function () {
+    resource.$syncTime = Date.now();
+    context.refresh(1);
+    // No outstanding requests
+  });
+
 });

--- a/src/resource.js
+++ b/src/resource.js
@@ -207,11 +207,11 @@ angular.module('hypermedia')
        * @returns a promise that is resolved to the resource
        * @see Resource#$syncTime
        */
-      $load: {value: function () {
-        if (this.$syncTime) {
-          return $q.when(this);
-        } else {
+      $load: {value: function (ts) {
+        if (!this.$syncTime || (ts && this.$syncTime < ts)) {
           return this.$context.httpGet(this);
+        } else {
+          return $q.when(this);
         }
       }},
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -201,9 +201,11 @@ angular.module('hypermedia')
       }},
 
       /**
-       * Perform an HTTP GET request if the resource is not synchronized.
+       * Perform an HTTP GET request if the resource is not synchronized or if
+       * the resource was synced before timestamp passed as argument.
        *
        * @function
+       * @param {number} ts timestamp to check against
        * @returns a promise that is resolved to the resource
        * @see Resource#$syncTime
        */

--- a/src/resource.spec.js
+++ b/src/resource.spec.js
@@ -236,7 +236,7 @@ describe('Resource', function () {
     expect(mockContext.httpGet).not.toHaveBeenCalled();
   });
 
-  it('does not load a resource again if it has been synced but stale', function () {
+  it('does not load a resource again if it has been synced and not stale', function () {
     resource.$syncTime = Date.now();
     resource.$load(new Date('2016-01-01').getTime());
     expect(mockContext.httpGet).not.toHaveBeenCalled();

--- a/src/resource.spec.js
+++ b/src/resource.spec.js
@@ -237,7 +237,7 @@ describe('Resource', function () {
   });
 
   it('does not load a resource again if it has been synced and not stale', function () {
-    resource.$syncTime = Date.now();
+    resource.$syncTime = new Date('2016-01-02');
     resource.$load(new Date('2016-01-01').getTime());
     expect(mockContext.httpGet).not.toHaveBeenCalled();
   });

--- a/src/resource.spec.js
+++ b/src/resource.spec.js
@@ -224,9 +224,21 @@ describe('Resource', function () {
     expect(mockContext.httpGet).toHaveBeenCalledWith(resource);
   });
 
+  it('loads a resource if it has been synced but stale', function () {
+    resource.$syncTime = new Date('2016-01-01').getTime();
+    resource.$load(Date.now());
+    expect(mockContext.httpGet).toHaveBeenCalledWith(resource);
+  });
+
   it('does not load a resource again if it has been synced', function () {
     resource.$syncTime = Date.now();
     resource.$load();
+    expect(mockContext.httpGet).not.toHaveBeenCalled();
+  });
+
+  it('does not load a resource again if it has been synced but stale', function () {
+    resource.$syncTime = Date.now();
+    resource.$load(new Date('2016-01-01').getTime());
     expect(mockContext.httpGet).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
It now accepts timestamp; only Resources that have been synced before
this moment are loaded from server.
