### PR TITLE
Let hypermedia be a proper CommonJS module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+require('./dist/hypermedia.js');
+
+/* commonjs package manager support (eg componentjs) */
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports) {
+  module.exports = 'hypermedia';
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hypermedia REST API client for AngularJS applications",
   "repository": "https://github.com/jcassee/angular-hypermedia",
   "license": "MIT",
-  "main": "dist/hypermedia.js",
+  "main": "index.js",
   "dependencies": {
     "angular": "^1.3",
     "linkheader-parser": "^0.1",


### PR DESCRIPTION
Just as angular modules (angular-messages, ui-router) published on NPM,
this module should be a proper commonjs module. This way it can be
`require()`d just as those modules.

Just as the official angular modules, this creates an index.js that does the
actual export, guarded by a commen check for a commonjs environment.

Fix for jcassee/angular-hypermedia#42